### PR TITLE
Implement change address detection

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,50 @@
+## Introduction
+
+This is a guide on how to use the Sia app on a Ledger Nano device.  The Sia app currently supports the Ledger Nano S and Ledger Nano X models and supports transactions involving Siacoins.
+
+## Requirements
+
+    - Initialized Ledger device with the latest firmware
+    - Ledger device connected to computer via USB
+    - Ledger Live open
+
+## Install the Sia App
+
+1. Select the **Manager** tab in Ledger Live
+2. Ensure you are on the **Apps Catalog** tab within the manager
+3. If prompted, allow the Ledger Manager access to your device
+4. Search for Sia within the app catalog
+5. Click install and wait for processing to complete
+6. Exit Ledger Live
+
+## Connecting to Sia Wallet
+
+1. Connect and unlock your Ledger device
+2. Ensure that Ledger Live does not have the manager open.  Leaving it open will interfere with the Sia web wallet and cause the Sia app to crash.
+3. Open the Sia app on the device
+4. Visit the [Sia Central Wallet website](https://wallet.siacentral.com/)
+5. When we first visit the Sia Central Wallet, we are prompted to set a password to encrypt the wallet(s) with.  Make sure to select a secure password.
+6. After typing and confirming the password, select **Ledger Wallet** as the type of wallet.
+7. Press the connect button and select your Ledger device
+8. Select **Import Public Key** and accept the public key request on your device
+9. Press done to confirm wallet importation
+
+## Using Sia Wallet
+
+### Viewing Balance
+
+The default screen of the Sia Central Wallet allows you to see your balance along with its value in USD.
+
+### Sending
+
+Press the **Send** button.  Then input the recipient address, along with the amount, denominated in either SC or USD.  Press **Send**, then confirm the transaction information on your Ledger device and then press accept to complete the signing.
+
+### Receiving
+
+Press the **Receive** button.  The address of your wallet represented in text and as a QR code will appear.
+
+## Finding Support / Communities
+
+- [Discord](https://discord.gg/sFCT3Ar)
+- [Forum](https://forum.sia.tech/)
+- [Sia Docs](https://support.sia.tech/)

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -8,6 +8,13 @@ This is a guide on how to use the Sia app on a Ledger Nano device.  The Sia app 
     - Ledger device connected to computer via USB
     - Ledger Live open
 
+## Enable Developer Mode
+The Sia app for Ledger devices can only be installed in developer mode.  To enable developer mode, do the following:
+
+1. Open the **Settings** tab in Ledger Live
+2. Select the **Experimental Features** tab within settings
+3. Enable the option titled **Developer Mode**
+
 ## Install the Sia App
 
 1. Select the **Manager** tab in Ledger Live

--- a/src/main.c
+++ b/src/main.c
@@ -131,7 +131,6 @@ bolos_ux_params_t G_ux_params;
 // by the computer instead of being initiated by the user. It typically just
 // contains an idle screen and a version screen.
 
-// this aligns better than "Waiting for commands"
 UX_STEP_NOCB(
 	ux_menu_ready_step,
 	nn,

--- a/src/txn.h
+++ b/src/txn.h
@@ -40,19 +40,21 @@ typedef struct {
 	txnElemType_e elemType; // type of most-recently-seen element
 	uint64_t sliceLen;      // most-recently-seen slice length prefix
 	uint16_t sliceIndex;    // offset within current element slice
+	uint16_t displayIndex;  // index of element being displayed
 
 	uint16_t sigIndex;   // index of TxnSig being computed
 	cx_blake2b_t blake;  // hash state
 	uint8_t sigHash[32]; // buffer to hold final hash
 
-	uint8_t outVal[128]; // most-recently-seen currency value, in decimal
-	uint8_t valLen;      // length of outVal
-	char outAddr[77]; // most-recently-seen address
+	uint8_t outVal[128];    // most-recently-seen currency value, in decimal
+	uint8_t valLen;         // length of outVal
+	uint8_t outAddr[77];    // most-recently-seen address
+	uint8_t changeAddr[77]; // change address
 } txn_state_t;
 
 // txn_init initializes a transaction decoder, preparing it to calculate the
 // requested SigHash.
-void txn_init(txn_state_t *txn, uint16_t sigIndex);
+void txn_init(txn_state_t *txn, uint16_t sigIndex, uint32_t changeIndex);
 
 // txn_update adds data to a transaction decoder.
 void txn_update(txn_state_t *txn, uint8_t *in, uint8_t inlen);


### PR DESCRIPTION
This change adds a `changeIndex` parameter, from which the change address can be derived. When displaying a transaction, outputs matching the change address are skipped.