### PR TITLE
Fix miner fees on Stax

### DIFF
--- a/src/txn.c
+++ b/src/txn.c
@@ -2,6 +2,7 @@
 
 #include <os.h>
 #include <string.h>
+#include <limits.h>
 
 #include "sia.h"  // For SW_DEVELOPER_ERR. Should be removed.
 
@@ -346,7 +347,12 @@ void txn_init(txn_state_t *txn, uint16_t sigIndex, uint32_t changeIndex) {
     txn->sigIndex = sigIndex;
 
     txn->elementIndex = 0;
-    txn->elements[txn->elementIndex].elemType = -1;  // first increment brings it to SC_INPUT
+#ifdef HAVE_NBGL
+    txn->lastSiacoinOutputIndex = USHRT_MAX;
+    txn->lastSiafundOutputIndex = USHRT_MAX;
+#endif
+    txn->elements[txn->elementIndex].elemType =
+        TXN_ELEM_SC_INPUT - 1;  // first increment brings it to TXN_ELEM_SC_INPUT
 
     uint8_t publicKey[65] = {0};
     deriveSiaPublicKey(changeIndex, publicKey);

--- a/src/txn.h
+++ b/src/txn.h
@@ -49,6 +49,10 @@ typedef struct {
     uint16_t pos;      // mid-decode offset; reset to 0 after each elem
 
     uint16_t elementIndex;
+#ifdef HAVE_NBGL
+    uint16_t lastSiacoinOutputIndex;
+    uint16_t lastSiafundOutputIndex;
+#endif
     txn_elem_t elements[MAX_ELEMS];  // only elements that will be displayed
 
     uint64_t sliceLen;    // most-recently-seen slice length prefix


### PR DESCRIPTION
Miner fees were not displayed correctly on Stax because the pairIndex from the UI was being used to derive the elementIndex incorrectly.  The elementIndex is used to find the miner fee "element" in the element array on the transaction context and through that the value of the fee.